### PR TITLE
fixed so genomes missing in flextaxd-database are downloaded from...

### DIFF
--- a/flextaxd/create_databases.py
+++ b/flextaxd/create_databases.py
@@ -215,7 +215,7 @@ def main():
 		process_directory_obj = process_directory(args.database)
 		genomes, missing = process_directory_obj.process_folder(args.genomes_path)
 		''' 2. Download missing files'''
-		if args.download or args.representative or args.download_file or 1:
+		if args.download or args.representative or args.download_file:
 			download = dynamic_import("modules", "DownloadGenomes")
 			download_obj = download(args.processes,outdir=args.tmpdir,force=args.force_download,download_path=args.genomes_path)
 			if args.download_file:

--- a/flextaxd/create_databases.py
+++ b/flextaxd/create_databases.py
@@ -130,7 +130,10 @@ def main():
 	if args.create_db and not args.genomes_path:
 		raise InputError("genomes_path parameter was not given")
 	if not os.path.exists(args.genomes_path):
-		raise FileNotFoundError("Directory {path} does not exist".format(path=args.genomes_path))
+		ans = input("Warning: directory for downloaded genomes does not exist, do you want to create it? (y/n): ")
+		if ans not in ["y","Y","yes", "Yes"]:
+			exit('terminating...')
+		os.makedirs(args.genomes_path)
 
 	if args.version:
 		print("{name}: version {version}".format(name=__pkgname__,version=__version__))
@@ -212,7 +215,7 @@ def main():
 		process_directory_obj = process_directory(args.database)
 		genomes, missing = process_directory_obj.process_folder(args.genomes_path)
 		''' 2. Download missing files'''
-		if args.download or args.representative or args.download_file:
+		if args.download or args.representative or args.download_file or 1:
 			download = dynamic_import("modules", "DownloadGenomes")
 			download_obj = download(args.processes,outdir=args.tmpdir,force=args.force_download,download_path=args.genomes_path)
 			if args.download_file:

--- a/flextaxd/modules/DownloadGenomes.py
+++ b/flextaxd/modules/DownloadGenomes.py
@@ -176,18 +176,19 @@ class DownloadGenomes(object):
 		'''Download files with ncbis download script using an accession input file'''
 		if not all:
 			exclude = " ".join([exclude,"--exclude-gff3 --exclude-protein --exclude-rna --exclude-genomic-cds"])
-		args = ["genome", "accession" ,"--inputfile", input_file, exclude"]
+		args = ["genome", "accession" ,"--inputfile", inputfile, exclude] # jacke, removed " after exclude and changed input_file to inputfile
 		p = Popen(args, stdout=PIPE,cwd=self.location)
 		(output, err) = p.communicate()
 		p_status = p.wait()
 		return self.location
 
-	def run(self, files, representative=False,url=""):
+	def run(self, files, representative=False,url="https://data.ace.uq.edu.au/public/gtdb/data/releases/latest/genomic_files_reps/gtdb_genomes_reps.tar.gz"): # jacke added url, before it was "" and it gave that to the self.download_representatives function...
 		'''Download list of GCF and or GCA files from NCBI or download represenative genomes
 
 		Parameters
 			list - list of GCF/GCA ids
 			bool - download representative genomes instead of list
+			url - e.g., https://data.ace.uq.edu.au/public/gtdb/data/releases/latest/genomic_files_reps/gtdb_genomes_reps.tar.gz or https://data.ace.uq.edu.au/public/gtdb/data/releases/latest/genomic_files_reps/bac120_marker_genes_reps.tar.gz # jacke
 
 		Returns
 			list - list of files not downloaded

--- a/flextaxd/modules/DownloadGenomes.py
+++ b/flextaxd/modules/DownloadGenomes.py
@@ -176,19 +176,19 @@ class DownloadGenomes(object):
 		'''Download files with ncbis download script using an accession input file'''
 		if not all:
 			exclude = " ".join([exclude,"--exclude-gff3 --exclude-protein --exclude-rna --exclude-genomic-cds"])
-		args = ["genome", "accession" ,"--inputfile", inputfile, exclude] # jacke, removed " after exclude and changed input_file to inputfile
+		args = ["genome", "accession" ,"--inputfile", inputfile, exclude]
 		p = Popen(args, stdout=PIPE,cwd=self.location)
 		(output, err) = p.communicate()
 		p_status = p.wait()
 		return self.location
 
-	def run(self, files, representative=False,url="https://data.ace.uq.edu.au/public/gtdb/data/releases/latest/genomic_files_reps/gtdb_genomes_reps.tar.gz"): # jacke added url, before it was "" and it gave that to the self.download_representatives function...
+	def run(self, files, representative=False,url="https://data.ace.uq.edu.au/public/gtdb/data/releases/latest/genomic_files_reps/gtdb_genomes_reps.tar.gz"):
 		'''Download list of GCF and or GCA files from NCBI or download represenative genomes
 
 		Parameters
 			list - list of GCF/GCA ids
 			bool - download representative genomes instead of list
-			url - e.g., https://data.ace.uq.edu.au/public/gtdb/data/releases/latest/genomic_files_reps/gtdb_genomes_reps.tar.gz or https://data.ace.uq.edu.au/public/gtdb/data/releases/latest/genomic_files_reps/bac120_marker_genes_reps.tar.gz # jacke
+			url - e.g., https://data.ace.uq.edu.au/public/gtdb/data/releases/latest/genomic_files_reps/gtdb_genomes_reps.tar.gz
 
 		Returns
 			list - list of files not downloaded

--- a/flextaxd/modules/DownloadGenomes.py
+++ b/flextaxd/modules/DownloadGenomes.py
@@ -56,7 +56,7 @@ class DownloadGenomes(object):
 				print(gen["genome_id"], end="\n", file=of)
 		return
 
-	def download_represenatives(self,genome_path,url="https://data.ace.uq.edu.au/public/gtdb/data/releases/latest/genomic_files_reps/bac120_marker_genes_reps.tar.gz"):
+	def download_represenatives(self,genome_path,url="https://data.ace.uq.edu.au/public/gtdb/data/releases/latest/genomic_files_reps/gtdb_genomes_reps.tar.gz"):
 		'''Specific function for GTDB download using their tar files instead of downloading from NCBI
 			Parameters
 				str - url


### PR DESCRIPTION
GTDB. The fix includes:

- If directory for genome sequences does not exist, notify the user and prompt for creation of directory
- Syntax error and mis-spelled variable
- Download of the proper file from GTDB (previous: bac120_marker_genes_reps.tar.gz, now: gtdb_genomes_reps.tar.gz)
  - I believe the code is not designed to parse the structure for marker_genes.
  - Note: The download of GTDB rep-set is slow.
  - Suggestion: Download missing accessions using NCBI "datasets" tool