### PR TITLE
Various fixes, primarliy related to downloading genomes

### DIFF
--- a/flextaxd/create_databases.py
+++ b/flextaxd/create_databases.py
@@ -232,7 +232,7 @@ def main():
 			download = dynamic_import("modules", "DownloadGenomes")
 			download_obj = download(args.processes,outdir=args.tmpdir,force=args.force_download,download_path=args.genomes_path)
 			if download_prompted:
-				download_obj.download_files(missing[:10]) # jacke, take only first 10 datasets
+				download_obj.download_files(missing)
 				 # Move downloaded files to genomes-directory
 				for path,dirs,files in os.walk(args.genomes_path+'/'+'downloads'):
 					for file_ in files:

--- a/flextaxd/create_databases.py
+++ b/flextaxd/create_databases.py
@@ -214,8 +214,23 @@ def main():
 		logger.info("Processing files; create kraken seq.map")
 		process_directory_obj = process_directory(args.database)
 		genomes, missing = process_directory_obj.process_folder(args.genomes_path)
+		
+		# If there are missing genome files, asks the user to attempt a download of these from gtdb
+		download_prompted = False
+		if missing:
+			print('There is a discrepancy of genomes found in the database and the specified genome-folder, {numMissing} genomes are missing.\n'.format(numMissing=len(missing)))
+			print('The names of missing genomes can be found in the file "FlexTaxD.missing", located in the temporary folder. You might need to specify --keep parameter to save the temporary folder.')
+			print('The "FlexTaxD.missing" file can be input to NCBI "datasets" command line software (https://www.ncbi.nlm.nih.gov/datasets/docs/v2/reference-docs/command-line/datasets/) to download any missing genome that has an accession number (e.g. when adding genomes that are not part of the GTDB representative dataset.\n')
+			if not args.download: # Dont ask to download if the user already specified via flag to download
+				ans = input('Do you want to attempt to find these genomes in the GTDB rep-set? (y/n) ')
+				if ans in ["y","Y","yes", "Yes"]:
+					download_prompted = True
+				else:
+					print('Will naivly proceed to construct database. Genomes may be missing.')
+		#/
+		
 		''' 2. Download missing files'''
-		if args.download or args.representative or args.download_file:
+		if args.download or args.representative or args.download_file or download_prompted:
 			download = dynamic_import("modules", "DownloadGenomes")
 			download_obj = download(args.processes,outdir=args.tmpdir,force=args.force_download,download_path=args.genomes_path)
 			if args.download_file:

--- a/flextaxd/modules/CreateKrakenDatabase.py
+++ b/flextaxd/modules/CreateKrakenDatabase.py
@@ -51,7 +51,7 @@ class CreateKrakenDatabase(object):
 			self.genome_names = list(genome_names.keys())   ## List for multiprocessing
 			self.genome_path = genome_names					## genome_id to path dictionary
 		else:
-			logger.error("Genome names are missing")
+			logger.error("Genome names are missing. Make sure your genomes are formatted as GCF_0000000.0.fasta[.gz]")
 		self.accession_to_taxid = self.database.get_genomes(self.database)
 		self.files = []
 		self.params = params
@@ -78,7 +78,7 @@ class CreateKrakenDatabase(object):
 				self.skiptax = self.parse_taxid_names(skip["tax_id"])
 				logger.info(self.skiptax)
 			else:
-				self.skiptax = parse_skip(skip.split(","))  ## if node should be skipd this must be true, otherwise nodes in modfile are added to existing database
+				self.skiptax = self.parse_skip(skip.split(","))  ## if node should be skipd this must be true, otherwise nodes in modfile are added to existing database
 
 		logger.info("{krakendb}".format(outdir = self.outdir, krakendb=self.krakendb))
 		if not os.path.exists("{krakendb}".format(outdir = self.outdir, krakendb=self.krakendb)):

--- a/flextaxd/modules/DownloadGenomes.py
+++ b/flextaxd/modules/DownloadGenomes.py
@@ -73,7 +73,7 @@ class DownloadGenomes(object):
 			ans = input("A represenative file already exist, (u)se file, (o)verwrite (c)ancel? (u o,c): ")
 			if ans in ["o", "O"]:
 				logger.info("Overwrite current progress")
-				os.remove("{file}".format(file=input_file_name))
+				os.remove(self.location+"/"+"{file}".format(file=input_file_name))
 			elif ans.strip() in ["u", "U"]:
 				logger.info("Resume database build")
 				return input_file_name

--- a/flextaxd/modules/ModifyTree.py
+++ b/flextaxd/modules/ModifyTree.py
@@ -265,7 +265,7 @@ class ModifyTree(object):
 		# ### Get the connecting link between the two databases
 		self.parent_link = self.taxonomydb.get_parent(self.taxonomydb.get_id(self.parent))
 		if not self.parent_link:
-			raise InputError("The selected parent node ({parent}) count not be found in the source database!".format(parent=self.parent))
+			raise InputError("The selected parent node ({parent}) could not be found in the source database!".format(parent=self.parent))
 		self.existing_nodes = self.taxonomydb.get_children(set([self.taxonomydb.get_id(self.parent)])) ## - set([self.taxonomydb.get_id(self.parent)] )
 		logger.info("{n} children to {parent}".format(n=len(self.existing_nodes),parent=self.parent))
 		if len(self.existing_nodes) > 0:

--- a/flextaxd/modules/NewickTree.py
+++ b/flextaxd/modules/NewickTree.py
@@ -148,7 +148,10 @@ class NewickTree(object):
 		tree = Phylo.read(StringIO(self.newickTree), "newick")
 		tree_nodes = set()
 		for node in tree.find_clades():
-			tree_nodes.add(node.name.lower())
+			try:
+				tree_nodes.add(node.name.lower())
+			except:
+				logger.info('Warning: node did not have a name: '+str(node))
 		#/
 		#print(tree_nodes.difference(db_nodes))
 		#print(db_nodes.difference(tree_nodes))


### PR DESCRIPTION
- Added display message to user about missing genomes when creating a kraken2 database.
- Added informative text to the display message that occurs when no genome is found by FTD (most often this should be due to faulty naming).
- FTD now prompts the user to download missing genomes during execution. I changed this since last pull request (self-closed) to now use the FTD-function to download genomes. 
- Fixed faulty function-referencing outside of object
- Added exception (skip/ignore) to nodes that do not have a name (e.g., it occurs when building a database from GTDB)