### PR TITLE
added --purge_database functionality to purge a FTD from genomes that…

### DIFF
--- a/flextaxd/create_databases.py
+++ b/flextaxd/create_databases.py
@@ -220,10 +220,13 @@ def main():
 		download_prompted = False
 		if missing and not (args.download or args.representative or args.download_file):
 			print('There is a discrepancy of genomes found in the database and the specified genome-folder, {numFound} genomes were found and {numMissing} genomes are missing.'.format(numFound=len(genomes),numMissing=len(missing)))
+			print('You may want to purge your database from missing genomes using "flextaxd --purge_database"')
 			if not args.download: # Dont ask to download if the user already specified via flag to download
-				ans = input('Do you want to download these genomes from NCBI? (y/n) ')
+				ans = input('Do you want to download these genomes from NCBI? (y)es, (n)o, (c)ancel: ')
 				if ans in ["y","Y","yes", "Yes"]:
 					download_prompted = True
+				elif type(ans) == str and not ans.isdigit() and ans.lower() in ('c','cancel',):
+					exit('Terminated.')
 				else:
 					print('Will naivly proceed to construct database. Genomes may be missing.')
 		#/
@@ -248,6 +251,9 @@ def main():
 			elif args.download_file:
 				download_obj.download_from_file(args.download_file)
 			else:
+				ans = input('Will attempt to get genomes from '+str(args.rep_path+'. Proceed? (y/n)'))
+				if not ans in ["yes","Yes","y","Y"]:
+					exit("Terminated.")
 				new_genome_path, missing = download_obj.run(missing,args.rep_path)
 				if not new_genome_path:
 					still_missing = missing


### PR DESCRIPTION
… are missing (including tree nodes and superfluous parent nodes)

More detailed specification about the implementation:
- It gets the nodes for these genomes and then traverses the tables of the FlexTaxD-database, removing entries (e.g. parent-relations) that are exclusive to such nodes. It tests so that any parent node is not a parent for a node that is not deleted.
- Optionally, missing genomes that have no distinct nodes in the tree can be removed (force_genome_delete).
  - This occurs when using GTDB taxonomy (full GTDB-database) but only using the representative genomes.
  - The nodes of such datasets have multiple children, of which one is the representative genome and the other children can be removed.
  - When this flag is applied, the function will remove missing entries from all tables wherever possible ("truly missing" datasets) in addition to naively removing all missing genomes (datasets that are missing due to exhaustive import of taxonomy information, such as import from GTDB)

Also made minor changes to user interaction related to missing genomes.