### PR TITLE
Init identical_nodes

### DIFF
--- a/flextaxd/modules/ModifyTree.py
+++ b/flextaxd/modules/ModifyTree.py
@@ -79,6 +79,7 @@ class ModifyTree(object):
 		self.clean = clean_database
 		self.taxonomy_type = False
 		self.do_not_delete_old = set()
+		self.identical_nodes = set() #init needed. Needed in get_id in parse_modification in elif modfile
 		try:
 			if kwargs["taxonomy_type"] != "NCBI":  ## If taxonomy type in merge database is set to NCBI, keep ranks also above 9, default no.
 				self.taxonomy_type = True


### PR DESCRIPTION
initiation of identical_nodes. Caused error when mod_file and not mod_database was used. identical_nodes is used in function get_id in parse_modification.