### PR TITLE
Multifasta support

### DIFF
--- a/flextaxd/create_databases.py
+++ b/flextaxd/create_databases.py
@@ -302,7 +302,12 @@ def main():
             # If there are missing genome files, asks the user to attempt a download of these from gtdb
             download_prompted = False
             if missing and not (args.download or args.representative or args.download_file):
-                print('There is a discrepancy of genomes found in the database and the specified genome-folder, {numFound} genomes were found and {numMissing} genomes are missing.'.format(numFound=len(genomes),numMissing=len(missing)))
+                num_found = len(genomes) + (len(mf_found) if args.multi_fasta else 0)
+                print('{numFound} genomes found ({numFolder} in genome folder{mf_info}), {numMissing} genomes in database not found in any source.'.format(
+                    numFound=num_found,
+                    numFolder=len(genomes),
+                    mf_info=", {n} in multi_fasta".format(n=len(mf_found)) if args.multi_fasta else "",
+                    numMissing=len(missing)))
                 print('You may want to purge your database from missing genomes using "flextaxd --purge_database"')
                 if not args.download: # Dont ask to download if the user already specified via flag to download
                     ans = input('Do you want to download these genomes from NCBI? (y)es, (n)o, (c)ancel: ')

--- a/flextaxd/create_databases.py
+++ b/flextaxd/create_databases.py
@@ -272,7 +272,10 @@ def main():
         if args.multifile_prefix:
             ## Process files including multifiles
             multifiles = process_directory_obj.get_multifiles() # rescan genomes directory
-        if args.multi_fasta and missing:
+        # Summary of genome sources
+        logger.warning("Genomes in database: {db}".format(db=len(process_directory_obj.genome_id_dict)))
+        logger.warning("Genomes found in genome folder: {n}".format(n=len(genomes)))
+        if args.multi_fasta:
             # Cross-check multi_fasta headers against database to find truly missing genomes
             if args.multi_fasta.endswith(".gz"):
                 import gzip
@@ -287,15 +290,13 @@ def main():
                         mf_accessions.add(accession)
             mf_found = set(m["genome_id"] for m in missing) & mf_accessions
             still_missing = [m for m in missing if m["genome_id"] not in mf_accessions]
-            logger.info("Genomes in database: {db}".format(db=len(process_directory_obj.genome_id_dict)))
-            logger.info("Genomes found in genome folder: {n}".format(n=len(genomes)))
-            logger.info("Sequences in multi_fasta: {n}".format(n=len(mf_accessions)))
-            logger.info("Sequences in multi_fasta matching database: {n}".format(n=len(mf_found)))
-            if still_missing:
-                logger.warning("Genomes not found in folder or multi_fasta: {n}".format(n=len(still_missing)))
-            else:
-                logger.info("All database genomes accounted for between folder and multi_fasta")
+            logger.warning("Sequences in multi_fasta: {n}".format(n=len(mf_accessions)))
+            logger.warning("Sequences in multi_fasta matching database: {n}".format(n=len(mf_found)))
             missing = still_missing
+        if missing:
+            logger.warning("Genomes not found in any source: {n}".format(n=len(missing)))
+        else:
+            logger.warning("All database genomes accounted for")
         while missing: # Experimental implementation: make user wary of missing genomes and force user to enter "no" in prompt to continue with missing genomes.
             ''' 2. Download missing files'''
             # If there are missing genome files, asks the user to attempt a download of these from gtdb

--- a/flextaxd/create_databases.py
+++ b/flextaxd/create_databases.py
@@ -238,25 +238,26 @@ def main():
             skip = True
         else:
             exit("Cancel execution!")
-    else:
-        if args.multi_fasta:
-            logger.info("Multi-fasta source transfered to library")
-            if not os.path.exists("{db_path}/library".format(db_path=args.db_name)):
-                os.makedirs("{db_path}/library".format(db_path=args.db_name))
-            if args.genomes_path:
-                # Both multi_fasta and genomes_path: process genomes first, append multi_fasta later
-                logger.info("Both --genomes_path and -mf provided; genomes will be processed first, then multi_fasta appended")
-            else:
-                # Only multi_fasta: copy to library and skip genome processing
-                cmd = "cp"
-                cmd2 = ""
-                if args.multi_fasta.endswith(".gz"):
-                    cmd = "zcat"
-                    cmd2 = " > "
-                os.system("{cmd} {large_source} {cmd2} {db_path}/library/library.fna".format(db_path=args.db_name, cmd=cmd, cmd2=cmd2, large_source=args.multi_fasta))
-                genomes=[args.multi_fasta]
-                args.genomes_path=os.path.dirname(args.multi_fasta)
-                skip=True
+
+    # Set up multi_fasta + genomes_path handling (runs for both new and overwritten libraries)
+    if not skip and args.multi_fasta:
+        logger.info("Multi-fasta source transfered to library")
+        if not os.path.exists("{db_path}/library".format(db_path=args.db_name)):
+            os.makedirs("{db_path}/library".format(db_path=args.db_name))
+        if args.genomes_path:
+            # Both multi_fasta and genomes_path: process genomes first, append multi_fasta later
+            logger.info("Both --genomes_path and -mf provided; genomes will be processed first, then multi_fasta appended")
+        else:
+            # Only multi_fasta: copy to library and skip genome processing
+            cmd = "cp"
+            cmd2 = ""
+            if args.multi_fasta.endswith(".gz"):
+                cmd = "zcat"
+                cmd2 = " > "
+            os.system("{cmd} {large_source} {cmd2} {db_path}/library/library.fna".format(db_path=args.db_name, cmd=cmd, cmd2=cmd2, large_source=args.multi_fasta))
+            genomes=[args.multi_fasta]
+            args.genomes_path=os.path.dirname(args.multi_fasta)
+            skip=True
 
     ''' 1. Process genome_path directory'''
     if not skip:

--- a/flextaxd/create_databases.py
+++ b/flextaxd/create_databases.py
@@ -271,6 +271,30 @@ def main():
         if args.multifile_prefix:
             ## Process files including multifiles
             multifiles = process_directory_obj.get_multifiles() # rescan genomes directory
+        if args.multi_fasta and missing:
+            # Cross-check multi_fasta headers against database to find truly missing genomes
+            if args.multi_fasta.endswith(".gz"):
+                import gzip
+                mf_open = gzip.open
+            else:
+                mf_open = open
+            mf_accessions = set()
+            with mf_open(args.multi_fasta, "rt") as fh:
+                for line in fh:
+                    if line.startswith(">"):
+                        accession = line[1:].split()[0]
+                        mf_accessions.add(accession)
+            mf_found = set(m["genome_id"] for m in missing) & mf_accessions
+            still_missing = [m for m in missing if m["genome_id"] not in mf_accessions]
+            logger.info("Genomes in database: {db}".format(db=len(process_directory_obj.genome_id_dict)))
+            logger.info("Genomes found in genome folder: {n}".format(n=len(genomes)))
+            logger.info("Sequences in multi_fasta: {n}".format(n=len(mf_accessions)))
+            logger.info("Sequences in multi_fasta matching database: {n}".format(n=len(mf_found)))
+            if still_missing:
+                logger.warning("Genomes not found in folder or multi_fasta: {n}".format(n=len(still_missing)))
+            else:
+                logger.info("All database genomes accounted for between folder and multi_fasta")
+            missing = still_missing
         while missing: # Experimental implementation: make user wary of missing genomes and force user to enter "no" in prompt to continue with missing genomes.
             ''' 2. Download missing files'''
             # If there are missing genome files, asks the user to attempt a download of these from gtdb
@@ -373,25 +397,15 @@ def main():
         if not skip:
             logger.info("Create library.fna")
             classifierDB.create_library_from_files(multifiles)
-            logger.info("Genomes processed: {n}".format(n=len(genomes)))
+            logger.info("Genomes processed from folder: {n}".format(n=len(genomes)))
             # Append multi_fasta to library.fna if both -mf and --genomes_path were provided
             if args.multi_fasta and args.genomes_path:
                 logger.info("Appending multi_fasta to library.fna")
                 if args.multi_fasta.endswith(".gz"):
-                    import gzip
-                    open_func = gzip.open
                     append_cmd = "zcat {src} >> {db_path}/library/library.fna"
                 else:
-                    open_func = open
                     append_cmd = "cat {src} >> {db_path}/library/library.fna"
-                # Count sequences in multi_fasta
-                mf_count = 0
-                with open_func(args.multi_fasta, "rt") as fh:
-                    for line in fh:
-                        if line.startswith(">"):
-                            mf_count += 1
                 os.system(append_cmd.format(src=args.multi_fasta, db_path=args.db_name))
-                logger.info("Sequences in multi_fasta: {n}".format(n=mf_count))
         logger.info("Genome folder preprocessing completed!")
 
     ''' 4. Create database'''

--- a/flextaxd/create_databases.py
+++ b/flextaxd/create_databases.py
@@ -87,7 +87,7 @@ def main():
     basic.add_argument('-db', '--database', '--db' ,metavar="", type=str, default=".ctdb" , help="Custom taxonomy sqlite3 database file")
     #basic.add_argument('--dump_map',metavar="", type=str, default=False , help="dump kraken2 prelim and seq2taxid maps, required for files with multiseq")
     basic.add_argument('--dump_map',action='store_true',help="dump kraken2 prelim and seq2taxid maps, required for files with multiseq")
-    basic.add_argument('-nt', '--nt_source', '--nt', metavar="",type=str, default=False, help="If part of your data is merged into one file, add path to file here, example nt")
+    basic.add_argument('-mf', '--multi_fasta', metavar="",type=str, default=False, help="Path to a multi-fasta file to include in the library (e.g. nt subset)")
     basic.add_argument('-mfp', '--multifile_prefix', metavar="",type=str,default=False, help="If multiple datafiles, list file prefix to handle as multi files")
 
     ### Download options, process local directory and potentially download files
@@ -175,9 +175,9 @@ def main():
         write_obj.dump_taxid_map()
         exit()
 
-    if args.create_db and not (args.genomes_path or args.nt_source):
+    if args.create_db and not (args.genomes_path or args.multi_fasta):
         raise InputError("genomes_path parameter was not given")
-    if not args.nt_source:
+    if not args.multi_fasta:
         if args.genomes_path != None and not os.path.exists(args.genomes_path):
             ans = input("Warning: directory for downloaded genomes does not exist, do you want to create it? (y/n): ")
             if ans not in ["y","Y","yes", "Yes"]:
@@ -225,11 +225,11 @@ def main():
         elif ans in ["m", "M"]:
             logger.info("Merge input fasta with library.fna")
             cmd = "cat"
-            if args.nt_source:
-                logger.info("Nucleotide source transfered to library")
-                if args.nt_source.endswith(".gz"):
+            if args.multi_fasta:
+                logger.info("Multi-fasta source transfered to library")
+                if args.multi_fasta.endswith(".gz"):
                     cmd = "zcat"
-                os.system("{cmd} {large_source} >> {db_path}/library/library.fna >> {large_source}".format(cmd=cmd, db_path=args.db_name, large_source=args.nt_source))
+                os.system("{cmd} {large_source} >> {db_path}/library/library.fna >> {large_source}".format(cmd=cmd, db_path=args.db_name, large_source=args.multi_fasta))
             else:
                 exit("No large input file given")
         elif ans.strip() in ["u", "U"]:
@@ -239,23 +239,24 @@ def main():
         else:
             exit("Cancel execution!")
     else:
-        if args.nt_source:
-            logger.info("Nucleotide source transfered to library")
-            #ans = input("Im here: ")
-            cmd = "cp"
-            cmd2 = ""
-            if args.nt_source.endswith(".gz"):
-                cmd = "zcat"
-                cmd2 = " > "
-            print("{cmd} {large_source} {cmd2} {db_path}/library/library.fna".format(db_path=args.db_name, cmd=cmd,cmd2=cmd2,large_source=args.nt_source))
-            ans = input("Write c to continue")
-            if ans != "c":
-               exit()
-            if not os.path.exists("{db_path}/library".format(db_path=args.db_name)): os.makedirs("{db_path}/library".format(db_path=args.db_name))
-            os.system("{cmd} {large_source} {cmd2} {db_path}/library/library.fna".format(db_path=args.db_name, cmd=cmd,cmd2=cmd2,large_source=args.nt_source))
-            genomes=[args.nt_source]
-            args.genomes_path=os.path.dirname(args.nt_source)
-            skip=True
+        if args.multi_fasta:
+            logger.info("Multi-fasta source transfered to library")
+            if not os.path.exists("{db_path}/library".format(db_path=args.db_name)):
+                os.makedirs("{db_path}/library".format(db_path=args.db_name))
+            if args.genomes_path:
+                # Both multi_fasta and genomes_path: process genomes first, append multi_fasta later
+                logger.info("Both --genomes_path and -mf provided; genomes will be processed first, then multi_fasta appended")
+            else:
+                # Only multi_fasta: copy to library and skip genome processing
+                cmd = "cp"
+                cmd2 = ""
+                if args.multi_fasta.endswith(".gz"):
+                    cmd = "zcat"
+                    cmd2 = " > "
+                os.system("{cmd} {large_source} {cmd2} {db_path}/library/library.fna".format(db_path=args.db_name, cmd=cmd, cmd2=cmd2, large_source=args.multi_fasta))
+                genomes=[args.multi_fasta]
+                args.genomes_path=os.path.dirname(args.multi_fasta)
+                skip=True
 
     ''' 1. Process genome_path directory'''
     if not skip:
@@ -372,6 +373,25 @@ def main():
         if not skip:
             logger.info("Create library.fna")
             classifierDB.create_library_from_files(multifiles)
+            logger.info("Genomes processed: {n}".format(n=len(genomes)))
+            # Append multi_fasta to library.fna if both -mf and --genomes_path were provided
+            if args.multi_fasta and args.genomes_path:
+                logger.info("Appending multi_fasta to library.fna")
+                if args.multi_fasta.endswith(".gz"):
+                    import gzip
+                    open_func = gzip.open
+                    append_cmd = "zcat {src} >> {db_path}/library/library.fna"
+                else:
+                    open_func = open
+                    append_cmd = "cat {src} >> {db_path}/library/library.fna"
+                # Count sequences in multi_fasta
+                mf_count = 0
+                with open_func(args.multi_fasta, "rt") as fh:
+                    for line in fh:
+                        if line.startswith(">"):
+                            mf_count += 1
+                os.system(append_cmd.format(src=args.multi_fasta, db_path=args.db_name))
+                logger.info("Sequences in multi_fasta: {n}".format(n=mf_count))
         logger.info("Genome folder preprocessing completed!")
 
     ''' 4. Create database'''

--- a/flextaxd/create_databases.py
+++ b/flextaxd/create_databases.py
@@ -87,7 +87,7 @@ def main():
     basic.add_argument('-db', '--database', '--db' ,metavar="", type=str, default=".ctdb" , help="Custom taxonomy sqlite3 database file")
     #basic.add_argument('--dump_map',metavar="", type=str, default=False , help="dump kraken2 prelim and seq2taxid maps, required for files with multiseq")
     basic.add_argument('--dump_map',action='store_true',help="dump kraken2 prelim and seq2taxid maps, required for files with multiseq")
-    basic.add_argument('-mf', '--multi_fasta', metavar="",type=str, default=False, help="Path to a multi-fasta file to include in the library (e.g. nt subset)")
+    basic.add_argument('-mf', '--multi_fasta', metavar="", nargs='+', default=[], help="Path(s) to multi-fasta file(s) to include in the library (e.g. nt subsets)")
     basic.add_argument('-mfp', '--multifile_prefix', metavar="",type=str,default=False, help="If multiple datafiles, list file prefix to handle as multi files")
 
     ### Download options, process local directory and potentially download files
@@ -177,7 +177,7 @@ def main():
 
     if args.create_db and not (args.genomes_path or args.multi_fasta):
         raise InputError("genomes_path parameter was not given")
-    if not args.multi_fasta:
+    if not args.multi_fasta:  # empty list is falsy
         if args.genomes_path != None and not os.path.exists(args.genomes_path):
             ans = input("Warning: directory for downloaded genomes does not exist, do you want to create it? (y/n): ")
             if ans not in ["y","Y","yes", "Yes"]:
@@ -227,9 +227,12 @@ def main():
             cmd = "cat"
             if args.multi_fasta:
                 logger.info("Multi-fasta source transfered to library")
-                if args.multi_fasta.endswith(".gz"):
-                    cmd = "zcat"
-                os.system("{cmd} {large_source} >> {db_path}/library/library.fna >> {large_source}".format(cmd=cmd, db_path=args.db_name, large_source=args.multi_fasta))
+                for mf_file in args.multi_fasta:
+                    if mf_file.endswith(".gz"):
+                        mf_cmd = "zcat"
+                    else:
+                        mf_cmd = "cat"
+                    os.system("{cmd} {large_source} >> {db_path}/library/library.fna".format(cmd=mf_cmd, db_path=args.db_name, large_source=mf_file))
             else:
                 exit("No large input file given")
         elif ans.strip() in ["u", "U"]:
@@ -248,15 +251,17 @@ def main():
             # Both multi_fasta and genomes_path: process genomes first, append multi_fasta later
             logger.info("Both --genomes_path and -mf provided; genomes will be processed first, then multi_fasta appended")
         else:
-            # Only multi_fasta: copy to library and skip genome processing
-            cmd = "cp"
-            cmd2 = ""
-            if args.multi_fasta.endswith(".gz"):
-                cmd = "zcat"
-                cmd2 = " > "
-            os.system("{cmd} {large_source} {cmd2} {db_path}/library/library.fna".format(db_path=args.db_name, cmd=cmd, cmd2=cmd2, large_source=args.multi_fasta))
-            genomes=[args.multi_fasta]
-            args.genomes_path=os.path.dirname(args.multi_fasta)
+            # Only multi_fasta: copy/append to library and skip genome processing
+            for i, mf_file in enumerate(args.multi_fasta):
+                redirect = ">" if i == 0 else ">>"
+                if mf_file.endswith(".gz"):
+                    os.system("zcat {src} {rd} {db_path}/library/library.fna".format(src=mf_file, rd=redirect, db_path=args.db_name))
+                elif i == 0:
+                    os.system("cp {src} {db_path}/library/library.fna".format(src=mf_file, db_path=args.db_name))
+                else:
+                    os.system("cat {src} >> {db_path}/library/library.fna".format(src=mf_file, db_path=args.db_name))
+            genomes=list(args.multi_fasta)
+            args.genomes_path=os.path.dirname(args.multi_fasta[0])
             skip=True
 
     ''' 1. Process genome_path directory'''
@@ -277,17 +282,15 @@ def main():
         logger.warning("Genomes found in genome folder: {n}".format(n=len(genomes)))
         if args.multi_fasta:
             # Cross-check multi_fasta headers against database to find truly missing genomes
-            if args.multi_fasta.endswith(".gz"):
-                import gzip
-                mf_open = gzip.open
-            else:
-                mf_open = open
+            import gzip
             mf_accessions = set()
-            with mf_open(args.multi_fasta, "rt") as fh:
-                for line in fh:
-                    if line.startswith(">"):
-                        accession = line[1:].split()[0]
-                        mf_accessions.add(accession)
+            for mf_file in args.multi_fasta:
+                mf_open = gzip.open if mf_file.endswith(".gz") else open
+                with mf_open(mf_file, "rt") as fh:
+                    for line in fh:
+                        if line.startswith(">"):
+                            accession = line[1:].split()[0]
+                            mf_accessions.add(accession)
             mf_found = set(m["genome_id"] for m in missing) & mf_accessions
             still_missing = [m for m in missing if m["genome_id"] not in mf_accessions]
             logger.warning("Sequences in multi_fasta: {n}".format(n=len(mf_accessions)))
@@ -408,11 +411,12 @@ def main():
             # Append multi_fasta to library.fna if both -mf and --genomes_path were provided
             if args.multi_fasta and args.genomes_path:
                 logger.info("Appending multi_fasta to library.fna")
-                if args.multi_fasta.endswith(".gz"):
-                    append_cmd = "zcat {src} >> {db_path}/library/library.fna"
-                else:
-                    append_cmd = "cat {src} >> {db_path}/library/library.fna"
-                os.system(append_cmd.format(src=args.multi_fasta, db_path=args.db_name))
+                for mf_file in args.multi_fasta:
+                    if mf_file.endswith(".gz"):
+                        append_cmd = "zcat {src} >> {db_path}/library/library.fna"
+                    else:
+                        append_cmd = "cat {src} >> {db_path}/library/library.fna"
+                    os.system(append_cmd.format(src=mf_file, db_path=args.db_name))
         logger.info("Genome folder preprocessing completed!")
 
     ''' 4. Create database'''

--- a/flextaxd/create_databases.py
+++ b/flextaxd/create_databases.py
@@ -216,6 +216,7 @@ def main():
         if not os.path.exists(args.outdir):
             os.system("mkdir -p {outdir}".format(outdir = args.outdir))
     skip=False
+    skip_genomes=False
     if os.path.exists("{db_path}/library/library.fna".format(db_path=args.db_name)):
         ans = input("Database library file already exist, (u)se library, (o)verwrite (c)ancel? (u o,c): ")
         if ans in ["o", "O"]:
@@ -225,30 +226,33 @@ def main():
             logger.info("Merge input fasta with library.fna")
             cmd = "cat"
             if args.nt_source:
+                logger.info("Nucleotide source transfered to library")
                 if args.nt_source.endswith(".gz"):
-                    cmd = "zcat"    
+                    cmd = "zcat"
                 os.system("{cmd} {large_source} >> {db_path}/library/library.fna >> {large_source}".format(cmd=cmd, db_path=args.db_name, large_source=args.nt_source))
             else:
                 exit("No large input file given")
         elif ans.strip() in ["u", "U"]:
             logger.info("Resume database build")
+            skip_genomes =True
             skip = True
         else:
             exit("Cancel execution!")
     else:
         if args.nt_source:
+            logger.info("Nucleotide source transfered to library")
             #ans = input("Im here: ")
             cmd = "cp"
             cmd2 = ""
             if args.nt_source.endswith(".gz"):
                 cmd = "zcat"
                 cmd2 = " > "
-            #print("{cmd} {large_source} {cmd2} {db_path}/library/library.fna".format(db_path=args.db_name, cmd=cmd,cmd2=cmd2,large_source=args.nt_source))
-            #ans = input("Write c to continue")
-            #if ans != "c":
-            #    exit()
-            #os.makedirs("{db_path}/library".format(db_path=args.db_name))
-            #os.system("{cmd} {large_source} {cmd2} {db_path}/library/library.fna".format(db_path=args.db_name, cmd=cmd,cmd2=cmd2,large_source=args.nt_source))
+            print("{cmd} {large_source} {cmd2} {db_path}/library/library.fna".format(db_path=args.db_name, cmd=cmd,cmd2=cmd2,large_source=args.nt_source))
+            ans = input("Write c to continue")
+            if ans != "c":
+               exit()
+            if not os.path.exists("{db_path}/library".format(db_path=args.db_name)): os.makedirs("{db_path}/library".format(db_path=args.db_name))
+            os.system("{cmd} {large_source} {cmd2} {db_path}/library/library.fna".format(db_path=args.db_name, cmd=cmd,cmd2=cmd2,large_source=args.nt_source))
             genomes=[args.nt_source]
             args.genomes_path=os.path.dirname(args.nt_source)
             skip=True
@@ -361,7 +365,8 @@ def main():
                                         debug=args.debug,
                                         verbose=args.verbose,
                                         tmpdir=args.tmpdir,
-                                        create_lib=args.create_lib
+                                        create_lib=args.create_lib,
+                                        skip_genomes=skip_genomes
         )
         report_time(current_time)
         if not skip:

--- a/flextaxd/custom_taxonomy_databases.py
+++ b/flextaxd/custom_taxonomy_databases.py
@@ -142,6 +142,7 @@ def main():
     out_opts.add_argument('--dump_descriptions', action='store_true', default=False,                help="Dump description names instead of database integers")
     out_opts.add_argument('--dump_genomes', action='store_true', default=False,                     help="Print list of genomes (and source) to file")
     out_opts.add_argument('--dump_genome_annotations', action='store_true', default=False,          help="Add genome taxid annotation to genomes dump")
+    out_opts.add_argument('--dump_map',action='store_true',help="dump kraken2 prelim and seq2taxid maps, required for files with multiseq")
 
     vis_opts = parser.add_argument_group('vis_opts', "Visualisation options")
     vis_opts.add_argument('--vis_node','--visualise_node', metavar='', default=False,                            help="Visualise tree from selected node")
@@ -395,6 +396,13 @@ def main():
             write_obj.set_prefix("names,taxDB")
             write_obj.set_order(True)
             write_obj.nodes()
+
+    if args.dump_map:
+        logger.info("Dump genome maps")
+        write_module = dynamic_import("modules", "WriteTaxonomy")
+        write_obj = write_module(args.outdir, database=args.database, dump_genome_map=True)
+        write_obj.dump_taxid_map()
+        exit()
 
     if args.vis_node:
         modify_module = dynamic_import("modules", "NewickTree")

--- a/flextaxd/custom_taxonomy_databases.py
+++ b/flextaxd/custom_taxonomy_databases.py
@@ -121,7 +121,7 @@ def main():
     mod_opts.add_argument('-md', '--mod_database', '--mod_db', metavar="",default=False,            help="Database file containing modifications")
     mod_opts.add_argument('-gt', '--genomeid2taxid', metavar="", default=False,         help="File that lists which node a genome should be assigned to")
     mod_opts.add_argument('-gp', '--genomes_path', metavar="",default=None,             help='Path to genome folder is required when using NCBI_taxonomy as source')
-    mod_opts.add_argument('--force_multisource',  action='store_true', default=False,   help='Inputfiles contains multiple sources')
+    mod_opts.add_argument('-mf', '--multi_fasta', metavar="", nargs='+', default=[],     help='Path(s) to multi-fasta file(s) to include (e.g. nt subsets)')
     
     #mod_opts.add_argument('-un', '--update_names', metavar="",default=None,             help='Update node names using old to new name file.')
     mod_opts.add_argument('--rename_from', metavar="",default=None,                     help='Updates a node name. Must be paired with --rename_to')
@@ -296,6 +296,27 @@ def main():
         for entry in missing:
             missing_genomes.add(entry['genome_id'])
         #/
+        # Cross-check multi_fasta headers against missing list
+        if args.multi_fasta and missing_genomes:
+            import gzip
+            mf_accessions = set()
+            for mf_path in args.multi_fasta:
+                if not os.path.exists(mf_path):
+                    logger.warning("Multi-fasta file not found: {f}".format(f=mf_path))
+                    continue
+                mf_open = gzip.open if mf_path.endswith(".gz") else open
+                with mf_open(mf_path, "rt") as fh:
+                    for line in fh:
+                        if line.startswith(">"):
+                            accession = line[1:].split()[0]
+                            mf_accessions.add(accession)
+            mf_found = missing_genomes & mf_accessions
+            if mf_found:
+                logger.info("Sequences in multi_fasta matching missing genomes: {n}".format(n=len(mf_found)))
+                missing_genomes -= mf_found
+                missing = [m for m in missing if m['genome_id'] not in mf_found]
+            logger.info("Sequences in multi_fasta total: {n}".format(n=len(mf_accessions)))
+        #/
         # Send genomes to have their nodes (and parents, when loosing all their childs) removes
         if missing:
             modify_module = dynamic_import("modules", "ModifyTree")
@@ -319,7 +340,7 @@ def main():
             '''Load taxonomy module'''
             logger.info("Loading module: ReadTaxonomy{type}".format(type=args.taxonomy_type))
             read_module = dynamic_import("modules", "ReadTaxonomy{type}".format(type=args.taxonomy_type))
-            read_obj = read_module(args.taxonomy_file, database=args.database,skip_annotation=args.skip_annotation,force_multisource=args.force_multisource)
+            read_obj = read_module(args.taxonomy_file, database=args.database,skip_annotation=args.skip_annotation,multi_fasta=args.multi_fasta)
             logger.info("Parse taxonomy")
             read_obj.parse_taxonomy()                                                           ## Parse taxonomy file
 

--- a/flextaxd/modules/CreateKrakenDatabase.py
+++ b/flextaxd/modules/CreateKrakenDatabase.py
@@ -118,6 +118,10 @@ class CreateKrakenDatabase(object):
 		jobs = []
 		manager = Manager()
 		added = manager.Queue()
+		## Close database connection before multiprocessing to allow pickling
+		db_path = self.database.database
+		self.database.conn.close()
+		self.database = None
 		for i in range(self.processes):
 			p = Process(target=self.kraken_fasta_header, args=(genomes[i],added))
 			p.daemon=True
@@ -125,6 +129,8 @@ class CreateKrakenDatabase(object):
 			jobs.append(p)
 		for job in jobs:
 			job.join()
+		## Restore database connection after multiprocessing
+		self.database = DatabaseFunctions(db_path)
 		self.added = added.qsize()
 		return "Processes done"
 

--- a/flextaxd/modules/CreateKrakenDatabase.py
+++ b/flextaxd/modules/CreateKrakenDatabase.py
@@ -57,8 +57,10 @@ class CreateKrakenDatabase(object):
 		if genome_names and not self.skip_genomes:
 			self.genome_names = list(genome_names.keys())   ## List for multiprocessing
 			self.genome_path = genome_names					## genome_id to path dictionary
+		elif self.skip_genomes:
+			logger.info("Skipping individual genome processing, using pre-built library.")
 		else:
-			logger.warning("Genome names are missing.") # Make sure your genomes are formatted as GCF_000000000.0.fasta[.gz]")
+			logger.warning("Genome names are missing. Make sure your genomes are formatted as GCF_000000000.0.fasta[.gz]")
 		self.accession_to_taxid = self.database.get_genomes(self.database)
 		self.files = []
 		self.params = params

--- a/flextaxd/modules/CreateKrakenDatabase.py
+++ b/flextaxd/modules/CreateKrakenDatabase.py
@@ -53,7 +53,8 @@ class CreateKrakenDatabase(object):
 			self.tmpdir = outdir
 		self.seqid2taxid = self.outdir+"/seqid2taxid.map"
 		logger.info("seqid2taxid file:{tfile}".format(tfile=self.seqid2taxid))
-		if genome_names:
+		self.skip_genomes = kwargs["skip_genomes"]
+		if genome_names and not self.skip_genomes:
 			self.genome_names = list(genome_names.keys())   ## List for multiprocessing
 			self.genome_path = genome_names					## genome_id to path dictionary
 		else:

--- a/flextaxd/modules/CreateKrakenDatabase.py
+++ b/flextaxd/modules/CreateKrakenDatabase.py
@@ -329,17 +329,23 @@ class CreateKrakenDatabase(object):
 			logger.info("cp {outdir}/*.map {krakendb}".format(outdir=outdir,krakendb=self.krakendb))
 		
 		if self.krakenversion == 'krakenuniq':
-			logger.info(self.krakenversion+"-build --build --db {krakendb} {params} --threads {threads}".format(krakendb=self.krakendb, threads=self.build_processes, params=self.params))
-			os.system(self.krakenversion+"-build --build --db {krakendb} {params} --threads {threads}".format(krakendb=self.krakendb, threads=self.build_processes, params=self.params))
+			build_cmd = self.krakenversion+"-build --build --db {krakendb} {params} --threads {threads}".format(krakendb=self.krakendb, threads=self.build_processes, params=self.params)
 		else:
-			logger.info(self.krakenversion+"-build --build --skip-maps --db {krakendb} {params} --threads {threads}".format(krakendb=self.krakendb, threads=self.build_processes, params=self.params))
-			os.system(self.krakenversion+"-build --build --skip-maps --db {krakendb} {params} --threads {threads}".format(krakendb=self.krakendb, threads=self.build_processes, params=self.params))
+			build_cmd = self.krakenversion+"-build --build --skip-maps --db {krakendb} {params} --threads {threads}".format(krakendb=self.krakendb, threads=self.build_processes, params=self.params)
+		logger.info(build_cmd)
+		build_ret = os.system(build_cmd)
+		if build_ret != 0:
+			logger.error("Database build failed with exit code {code}".format(code=build_ret))
+			return
 
 		if self.krakenversion in ["kraken2"]:
 			logger.info("Create inspect file!")
-			os.system(self.krakenversion+"-inspect --db {krakendb} --report-zero-counts --threads {threads} > {krakendb}/inspect.txt".format(krakendb=self.krakendb,threads=self.build_processes ))
+			inspect_ret = os.system(self.krakenversion+"-inspect --db {krakendb} --report-zero-counts --threads {threads} > {krakendb}/inspect.txt".format(krakendb=self.krakendb,threads=self.build_processes ))
+			if inspect_ret != 0:
+				logger.error("kraken2-inspect failed with exit code {code}".format(code=inspect_ret))
+			else:
+				os.system("gzip {krakendb}/inspect.txt".format(krakendb=self.krakendb))
 			os.system("gzip {krakendb}/*.map".format(krakendb=self.krakendb))
-			os.system("gzip {krakendb}/inspect.txt".format(krakendb=self.krakendb))
 		if not keep:
 			os.system(self.krakenversion+"-build --clean --db {krakendb}".format(outdir=outdir,krakendb=self.krakendb, threads=self.processes))
 			## re-add taxonomy

--- a/flextaxd/modules/ReadTaxonomyNCBI.py
+++ b/flextaxd/modules/ReadTaxonomyNCBI.py
@@ -21,7 +21,7 @@ class ReadTaxonomyNCBI(ReadTaxonomy):
 		self.length = 0
 		self.ids = 0
 		self.accessionfile = False
-		self.force_multisource = kwargs["force_multisource"]
+		self.multi_fasta = kwargs.get("multi_fasta", [])
 
 	def write_missing(self,missing):
 		'''Write missing genomes to file'''
@@ -103,26 +103,23 @@ class ReadTaxonomyNCBI(ReadTaxonomy):
 		file_endings = (".fna",".fa",".fasta")
 		logger.info("Parsing ncbi accession2taxid, genome_path: {dir}".format(dir = genomes_path))
 		self.refseqid_to_GCF = {}
+		# Phase 1: Process explicitly specified multi-fasta files
+		multi_fasta_abs = set()
+		for mf_path in self.multi_fasta:
+			mf_abs = os.path.abspath(mf_path)
+			multi_fasta_abs.add(mf_abs)
+			if os.path.exists(mf_path):
+				self.parse_nt_file(mf_path, os.path.basename(mf_path))
+			else:
+				logger.warning("Multi-fasta file not found: {f}".format(f=mf_path))
+		# Phase 2: Walk genomes_path, treat all files as single-genome (skip multi_fasta files)
 		for root, dirs, files in os.walk(genomes_path,followlinks=True):
 			for filename in files:
 				if filename.strip(".gz").endswith(file_endings):
 					filepath = os.path.join(root, filename)
-					if filename.startswith("GC") and filename.rstrip(".gz").endswith(".fna"):
-						self.parse_genebank_file(filepath,filename)
-					elif filename.startswith("nt") or self.force_multisource:
-						if self.force_multisource:
-							self.parse_nt_file(filepath,filename)
-						else:
-							reference="nt" 
-							if filename.endswith(".gz"): 
-								compressed=True 
-							else: 
-								compressed=False
-							stats = os.stat(filepath)
-							logger.info("Parsing nt archive, filesize: {filesize}Mb, compressed: {compressed}".format(compressed=compressed,filesize=(stats.st_size / (1024 * 1024))))
-							self.parse_nt_file(filepath,filename)
-					else:
-						self.parse_genebank_file(filepath,filename)
+					if os.path.abspath(filepath) in multi_fasta_abs:
+						continue
+					self.parse_genebank_file(filepath,filename)
 		logger.info("genomes folder read, {n} sequence files found".format(n=len(self.refseqid_to_GCF)))
 		if not annotation_file.endswith("accession2taxid.gz"):
 			raise TypeError("The supplied annotation file does not seem to be the ncbi nucl_gb.accession2taxid.gz")


### PR DESCRIPTION
# Summary of all changes on multifasta_support branch (vs master)

This documents every change made across the branch (8 commits) plus the latest uncommitted edits, organized by file.

---

## flextaxd/create_databases.py

### Argument rename: -nt/--nt_source → -mf/--multi_fasta

- **Old:** `-nt/--nt_source`, `type=str`, `default=False`
- **New:** `-mf/--multi_fasta`, `nargs='+'`, `default=[]`
- All references to `args.nt_source` replaced with `args.multi_fasta`

### Added skip_genomes flag

- New variable `skip_genomes=False` initialized alongside `skip`
- Set to `True` when user chooses "use library" (u/U option)
- Passed to `CreateKrakenDatabase` constructor as `skip_genomes=skip_genomes`

### Multi-fasta + genomes_path handling restructured

- **Old:** The `nt_source` block was inside an `else` of the `library.fna` exists check, so it was skipped if the library already existed
- **New:** Extracted into a standalone block `if not skip and args.multi_fasta:` that runs for both new and overwritten libraries
- When both `--genomes_path` and `-mf` are provided: genomes processed first, then multi_fasta appended to `library.fna`
- When only `-mf`: files copied/appended to library (first file with `cp/>`, rest with `cat >>/>>`) and genome processing skipped
- All single-file string operations converted to loops over the list

### Merge mode (m/M option) updated

- Loops over `args.multi_fasta` list with per-file gz detection
- Fixed original broken command that had `>> {large_source}` at the end

### Cross-check of multi_fasta headers against missing genomes (new)

- After `process_folder()`, reads FASTA headers from all `-mf` files
- Computes `mf_found` (intersection of missing genome IDs and multi_fasta accessions)
- Filters missing to exclude multi_fasta-covered accessions
- Logs summary: genomes in DB, found in folder, in multi_fasta, still missing

### Genome source summary logging (new)

- Added `logger.warning()` calls showing: DB genome count, folder genome count, multi_fasta counts, missing counts
- Updated the download prompt message to show folder + multi_fasta counts separately

### Append multi_fasta after genome processing (new)

- After `create_library_from_files()`, if both `-mf` and `--genomes_path` provided, appends each multi_fasta file to `library.fna`
- Loops over list with per-file gz detection

---

## flextaxd/custom_taxonomy_databases.py

### Argument change: --force_multisource → -mf/--multi_fasta

- **Old:** `--force_multisource`, `action='store_true'`, `default=False`
- **New:** `-mf/--multi_fasta`, `nargs='+'`, `default=[]`

### ReadTaxonomyNCBI instantiation updated

- **Old:** `force_multisource=args.force_multisource`
- **New:** `multi_fasta=args.multi_fasta`

### Added --dump_map argument and handler (new)

- New argument: `--dump_map`, `action='store_true'`
- New handler block that calls `WriteTaxonomy` with `dump_genome_map=True` and `dump_taxid_map()`

### Purge logic: multi_fasta cross-check (new)

- After `process_folder()` collects missing genomes, reads headers from all `-mf` files
- Excludes multi_fasta-covered accessions from the `missing_genomes` set before purging
- Logs counts of matched and total multi_fasta sequences

---

## flextaxd/modules/ReadTaxonomyNCBI.py

### __init__: force_multisource → multi_fasta

- **Old:** `self.force_multisource = kwargs["force_multisource"]`
- **New:** `self.multi_fasta = kwargs.get("multi_fasta", [])`

### parse_genomeid2taxid: two-phase rewrite

- **Phase 1:** Loop over `self.multi_fasta` paths, call `parse_nt_file()` for each; build set of absolute paths to avoid double-processing
- **Phase 2:** Walk `genomes_path` with `os.walk(followlinks=True)`, treat ALL files as single-genome (`parse_genebank_file`), skip files whose absolute path is in the multi_fasta set
- **Removed:** 
  - `filename.startswith("nt")` auto-detection
  - `filename.startswith("GC")` special-casing
  - All `force_multisource` branching
  - Filesize/compressed logging for nt files

---

## flextaxd/modules/CreateKrakenDatabase.py

### skip_genomes support (new)

- Reads `kwargs["skip_genomes"]` in `__init__`
- When `skip_genomes=True` and `genome_names` provided, skips genome list setup and logs info message

### Multiprocessing pickle fix

- Before spawning processes in `create_library_fasta()`: closes `self.database.conn` and sets `self.database = None`
- After processes complete: restores `self.database` by reconnecting with `DatabaseFunctions(db_path)`
- Fixes sqlite3 pickling error on Python 3.14

### Error checking for kraken2 build and inspect

- `kraken2-build` return code checked; logs error and returns early on failure
- `kraken2-inspect` return code checked; only gzips `inspect.txt` on success
- `inspect.txt` gzip moved inside the success branch (was previously always run)
- `*.map` gzip moved to always run regardless of inspect result

### Minor: improved warning message

- Changed "Genome names are missing." to include formatting hint